### PR TITLE
Removed dependence on baseurl

### DIFF
--- a/_includes/download-links.html
+++ b/_includes/download-links.html
@@ -3,7 +3,7 @@
   <tr>
     <th><span class="icon icon-{{pkg[0]}}"></span> {{ pkg[0] | capitalize }}</th>
     <td>
-        <a href="{{site.baseurl}}download/{{ pkg[1] }}" class="btn btn-primary">
+        <a href="/download/{{ pkg[1] }}" class="btn btn-primary">
         <span class="glyphicon glyphicon-download-alt"></span> {{ pkg[1] }}</a>
     </td>
   </tr>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{{ site.baseurl }}">
+          <a class="navbar-brand" href="/">
             <span style="font-family: monospace;">
               <span style="color:#839496">BNFC</span>
               <span style="color:#859900;">::=</span>


### PR DESCRIPTION
Baseurl was changing when navigating the the download page.
I don't know why. Possibly something GitHub specific.
This will keep working as long as the site stays at the root
of the domain (without sub paths)